### PR TITLE
remove this2 reaction

### DIFF
--- a/Sources/SwiftDEBot/main.swift
+++ b/Sources/SwiftDEBot/main.swift
@@ -26,6 +26,7 @@ bot.on(.reactionAdd) { data in
 
     if emoji.name == "this2" {
         bot.addReaction("a:this:785804431597240351", to: messageID, in: channel.id)
+        bot.deleteReaction(":this2:784350423862870016", from: messageID, in: channel.id)
     }
 }
 


### PR DESCRIPTION
This doesn't appear to be working yet, I only see generic rate limiting errors on trying to remove the reaction. I'm guessing this is because the bot doesn't have the necessary permission, but I'm not sure which one to grant, "manage messages" is the only one that appears to make sense.

Or maybe this isn't just as easy as calling `deleteReaction`? 🤷‍♀️ 