### PR TITLE
Add version command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ RUN apt-get update && apt-get install -y libsodium-dev
 
 WORKDIR /app
 COPY . ./
-RUN swift build --configuration release
+RUN make build
 
 # FROM swift:5.3-slim
 FROM swift:4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+update-version:
+	swift Scripts/UpdateVersion.swift
+
+build: update-version
+	swift build --configuration release
+
+.PHONY: update-version, build

--- a/Scripts/UpdateVersion.swift
+++ b/Scripts/UpdateVersion.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+func getCurrentProjectVersion() throws -> String? {
+    let git = Process()
+    git.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+    git.arguments = ["describe", "--abbrev=0", "--tags"]
+    let output = Pipe()
+    git.standardOutput = output
+    try git.run()
+    let data = output.fileHandleForReading.readDataToEndOfFile()
+    return String(data: data, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+
+let version = try! getCurrentProjectVersion() ?? "unknown"
+
+let fileManager = FileManager.default
+let pathToVersion = fileManager.currentDirectoryPath + "/Sources/SwiftDEBot/Utils/Version.swift"
+
+let versionDecl = #"""
+// This file is automatically updated on running `make update-version`. Please don't check any changes into git.
+let VERSION = "\#(version)"
+"""#
+try! versionDecl.write(toFile: pathToVersion, atomically: false, encoding: .utf8)

--- a/Sources/SwiftDEBot/Command/Message Commands/Command+Version.swift
+++ b/Sources/SwiftDEBot/Command/Message Commands/Command+Version.swift
@@ -1,0 +1,10 @@
+import Sword
+
+extension Command where Trigger == Message {
+    static let version = Command(
+        run: { bot, message in
+            guard message.content == "!version" else { return }
+            bot.send("🤖 \(VERSION)", to: message.channel.id)
+        }
+    )
+}

--- a/Sources/SwiftDEBot/Utils/Version.swift
+++ b/Sources/SwiftDEBot/Utils/Version.swift
@@ -1,0 +1,2 @@
+// This file is automatically updated on running `make update-version`. Please don't check any changes into git.
+let VERSION = "unspecified"

--- a/Sources/SwiftDEBot/main.swift
+++ b/Sources/SwiftDEBot/main.swift
@@ -12,7 +12,8 @@ bot.onMessageCreate(
     .hello,
     .hearts,
     .ping,
-    .xcode
+    .xcode,
+    .version
 )
 
 bot.onReactionAdd(


### PR DESCRIPTION
This currently fails on two things:

```
Scripts/UpdateVersion.swift:9:9: error: value of type 'Process' has no member 'run'
    try git.run()
        ^~~ ~~~
Scripts/UpdateVersion.swift:21:17: error: invalid escape sequence in literal
let VERSION = "\#(version)"
```

The second could be worked around until a current version of Swift can be used here. No clue about the first one though. Is that also a Foundation with Swift 4 issue?